### PR TITLE
ci: add Github action that runs oms validate

### DIFF
--- a/.github/workflows/oms.yml
+++ b/.github/workflows/oms.yml
@@ -1,0 +1,19 @@
+name: Open Microservices Validation
+
+# Trigger the workflow on push or pull request
+on: [push, pull_request]
+
+jobs:
+  oms-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Install Open Microservices CLI
+        run: yarn add @microservices/oms
+
+      - name: Validate `oms.yml`
+        run: node_modules/.bin/oms validate


### PR DESCRIPTION
Adding a GitHub action (originally author by Aurelien and Aditya independently of one another) that runs `oms validate` when a new PR is created. 

Developers who fork this repo, clone, or otherwise use it as a template will now automatically have `oms validate` run each time they:

1. Push to a branch
2. Open a PR

This addition helps provide guardrails for those new to the ecosystem, and helps experienced Open Microservices developers to ship updates with ease.